### PR TITLE
Add Postgres test support and Prisma updates

### DIFF
--- a/webserver/package-lock.json
+++ b/webserver/package-lock.json
@@ -13,6 +13,7 @@
         "@prisma/client": "^7.2.0",
         "@types/express": "^5.0.5",
         "@types/node": "^24.10.1",
+        "dotenv": "^17.2.3",
         "express": "^5.1.0",
         "pg": "^8.17.1",
         "prisma": "^6.19.2",
@@ -761,6 +762,18 @@
         }
       }
     },
+    "node_modules/c12/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -916,9 +929,9 @@
       "license": "MIT"
     },
     "node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "version": "17.2.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
+      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"

--- a/webserver/package.json
+++ b/webserver/package.json
@@ -15,13 +15,16 @@
   "type": "commonjs",
   "main": "App.js",
   "scripts": {
-    "start": "tsc && node ./dist/App.js"
+    "prisma:check": "prisma validate && prisma generate",
+    "start": "tsc && node ./dist/App.js",
+    "build": "npm run prisma:check && tsc"
   },
   "dependencies": {
     "@prisma/adapter-pg": "^7.2.0",
     "@prisma/client": "^7.2.0",
     "@types/express": "^5.0.5",
     "@types/node": "^24.10.1",
+    "dotenv": "^17.2.3",
     "express": "^5.1.0",
     "pg": "^8.17.1",
     "prisma": "^6.19.2",

--- a/webserver/src/App.ts
+++ b/webserver/src/App.ts
@@ -1,9 +1,11 @@
-import express, { Request, Response } from 'express';
-import fs from 'fs';
+import 'dotenv/config'
+import express, {Request, Response} from 'express';
+import fs from 'node:fs';
+import {resolve} from "node:path";
 
-// TODO: Shove this into a .env file
-const PORT: number = 3000;
-const SOURCE_DIR: string = __dirname + '/routes';
+const PORT: number = Number(process.env.PORT);
+const SOURCE_DIR: string = resolve(__dirname + '/routes');
+
 
 const app: express.Express = express();
 

--- a/webserver/src/routes/health.ts
+++ b/webserver/src/routes/health.ts
@@ -1,0 +1,19 @@
+import {Request, Response} from 'express';
+import {getPrisma} from '../db/client';
+
+export async function GET(req: Request, res: Response) {
+    let prisma = getPrisma();
+    try {
+        await prisma.$queryRaw`SELECT 1`;
+        res.status(200).json({
+            status: "ok",
+            uptime: process.uptime(),
+            timestamp: new Date().toISOString(),
+        });
+    } catch (err) {
+        console.log("Error connecting to DB:", err);
+        res.status(503).json({
+            status: "degraded",
+        });
+    }
+}


### PR DESCRIPTION
Added support for env variables:

* DATABASE_URL (default can be postgresql://postgres:postgres@localhost:5432/ritapp )
* PORT (default 3000) or whatever

Also added a test route for Postgres to make sure it successfully works after changes to move postgres to unbundle it.