### PR TITLE
Cache AutoScheduler

### DIFF
--- a/webserver/src/App.ts
+++ b/webserver/src/App.ts
@@ -2,6 +2,7 @@ import 'dotenv/config'
 import express, {Request, Response} from 'express';
 import fs from 'node:fs';
 import {extname, resolve, sep} from "node:path";
+import { CacheScheduler } from './lib/cache-scheduler/scheduler';
 
 const PORT: number = Number(process.env.PORT) || 3000; // I didn't make a .env file D:
 const SOURCE_DIR: string = resolve(__dirname + '/routes');
@@ -9,6 +10,8 @@ const SOURCE_DIR: string = resolve(__dirname + '/routes');
 
 const app: express.Express = express();
 app.use(express.json()); // Middleware to parse JSON bodies
+
+const scheduler = new CacheScheduler();
 
 app.get('/', (req: Request, res: Response) => {
     res.send('Hello, World!');
@@ -34,6 +37,11 @@ const registerRouteModule = (modulePath: string, routePath: string, file: string
     }
     if(route.DELETE) {
         app.delete(routePath, route.DELETE);
+    }
+    if (route.CACHEJOB) {
+        const { key, intervalMs, fetcher } = route.CACHEJOB;
+        scheduler.registerLoop(key, intervalMs, fetcher);
+        console.log(`Registered cache job: [${key}] from file: ${file}`);
     }
     console.log(`Loaded route: [${routePath}] from file: ${file}`);
 }
@@ -67,6 +75,11 @@ const recursiveLoadRoutes = (dir: string) => {
             if(route.DELETE) {
                 app.delete(routePath, route.DELETE);
             }
+            if (route.CACHEJOB) {
+                const { key, intervalMs, fetcher } = route.CACHEJOB;
+                scheduler.registerLoop(key, intervalMs, fetcher);
+                console.log(`Registered cache job: [${key}] from file: ${file}`);
+            }
             // Add other HTTP methods as needed
             console.log(`Loaded route: [${routePath}] from file: ${file}`);
             return;
@@ -85,6 +98,15 @@ const recursiveLoadRoutes = (dir: string) => {
 
 recursiveLoadRoutes(SOURCE_DIR);
 
-app.listen(PORT, () => {
+const server = app.listen(PORT, () => {
     console.log(`Server is running on http://localhost:${PORT}`);
+    scheduler.start();
 });
+
+const shutdown = () => {
+    scheduler.stop();
+    server.close(() => process.exit(0));
+};
+
+process.on('SIGTERM', shutdown);
+process.on('SIGINT', shutdown);

--- a/webserver/src/App.ts
+++ b/webserver/src/App.ts
@@ -2,7 +2,7 @@ import 'dotenv/config'
 import express, {Request, Response} from 'express';
 import fs from 'node:fs';
 import {extname, resolve, sep} from "node:path";
-import { CacheScheduler } from './lib/cache-scheduler/scheduler';
+import { scheduler } from './lib/cache-scheduler/scheduler';
 
 const PORT: number = Number(process.env.PORT) || 3000; // I didn't make a .env file D:
 const SOURCE_DIR: string = resolve(__dirname + '/routes');
@@ -10,8 +10,6 @@ const SOURCE_DIR: string = resolve(__dirname + '/routes');
 
 const app: express.Express = express();
 app.use(express.json()); // Middleware to parse JSON bodies
-
-const scheduler = new CacheScheduler();
 
 app.get('/', (req: Request, res: Response) => {
     res.send('Hello, World!');

--- a/webserver/src/lib/cache-scheduler/README.md
+++ b/webserver/src/lib/cache-scheduler/README.md
@@ -1,0 +1,84 @@
+# Cache Scheduler
+
+This module is the successor to [`src/db/cache.ts`](../../db/cache.ts). It replaces the current request-driven cache model with an auto-scheduled system that refreshes data proactively, independent of incoming user requests.
+
+## Problem with the current system
+
+`ScrapeCache` in `src/db/cache.ts` works on a **lazy, request-triggered** model:
+
+1. A user request comes in.
+2. The route checks `inCache()` and `isExpired()`.
+3. If the cache is stale or missing, the route performs a fresh scrape — while the user waits.
+4. The newly scraped data is stored, then returned.
+
+This means **the user pays the cost of a full scrape** any time the cache is cold or expired. For slow scrapes (e.g. dining locations, which fetches a detail page per restaurant), this can be several seconds of latency.
+
+## How the auto-scheduler works
+
+The cache scheduler decouples cache refresh from user requests entirely:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Scheduler (background)                                      │
+│  Runs on a fixed interval per cache key                      │
+│  Fetches fresh data → writes to cache                        │
+└─────────────────────────────────────────────────────────────┘
+            ↑ independent of user traffic
+
+┌─────────────────────────────────────────────────────────────┐
+│  Route handler (user request)                               │
+│  Always reads from cache → returns immediately              │
+│  Never triggers a scrape                                    │
+└─────────────────────────────────────────────────────────────┘
+```
+
+On startup, the scheduler registers a job for each cache key (e.g. `dining_locations`, `rit_events`). Each job runs on its own interval, fetches fresh data, and writes it to the cache — regardless of whether any user has asked for it.
+
+When a user request arrives, the route simply reads whatever is currently in cache and returns it instantly. No scrape, no wait.
+
+## Stale-while-revalidate
+
+If a background refresh is in progress when a request arrives, the route still serves the **existing (slightly stale) cached data** immediately. The refresh completes concurrently and the next request gets the fresh version. Users never block on a refresh.
+
+```
+t=0   Scheduler starts refresh for dining_locations
+t=0   User request arrives → served from current cache (instant)
+t=3s  Scheduler finishes refresh → cache updated
+t=3s  Next user request → served from fresh cache (instant)
+```
+
+## What this improves
+
+| | Old system | Cache scheduler |
+|---|---|---|
+| Cold cache latency | Full scrape time (seconds) | Instant (served from cache) |
+| Expired cache latency | Full scrape time (seconds) | Instant (background refresh in progress) |
+| Cache refresh trigger | User request | Scheduler (independent) |
+| Concurrent requests during refresh | All wait on the scrape | All served from existing cache |
+
+## Scope: consistent caches only
+
+The auto-scheduler applies to caches that are **general and consistent** — data that is the same for all users and fetched from a single, predictable source (e.g. the full dining locations list, the events feed).
+
+It is **not suited** for dynamic or combinatorial queries where the data space is too large or varied to pre-fetch in full. A good example is per-location dining detail pages: there are many locations, each requiring its own request, and proactively hitting all of them on every refresh cycle would place unnecessary strain on RIT's servers.
+
+For those cases, **lazy fetching remains the right approach** — fetch on demand, cache the result, and serve from cache on subsequent requests. The scheduler handles the broad strokes; lazy caching handles the fine-grained queries.
+
+A useful heuristic: if the full dataset can be fetched in one or a small fixed number of requests, schedule it. If the query space is driven by user input or enumerating many individual resources, keep it lazy.
+
+## Relationship to `src/db/cache.ts`
+
+The scheduler builds on top of `ScrapeCache` — it uses the same `getCache` / `setCache` / `isExpired` primitives as the storage layer. Routes that migrate to the scheduler can drop their inline `inCache` / `isExpired` / scrape logic and just call `getCache`. The scheduler handles the rest.
+
+`ScrapeCache` itself may eventually be simplified or moved in-memory (as the `TODO` in that file notes) once all routes have migrated.
+
+## Cache keys
+
+Each data source has its own named cache key and refresh interval registered with the scheduler:
+
+| Cache key | Source | Refresh interval |
+|---|---|---|
+| `dining_locations` | `rit.edu/dining/locations` | TBD |
+| `rit_events` | campusgroups.rit.edu events API | TBD |
+
+Add new entries here as routes migrate to the scheduler.

--- a/webserver/src/lib/cache-scheduler/scheduler.ts
+++ b/webserver/src/lib/cache-scheduler/scheduler.ts
@@ -1,7 +1,5 @@
-import { ScrapeCache } from "../../db/cache";
-import { PrismaClient } from "@prisma/client"
-import {getPrisma} from "../../db/client"
-
+import { PrismaClient } from "@prisma/client";
+import { getPrisma } from "../../db/client";
 
 type CacheJob = {
     key: string;
@@ -10,9 +8,16 @@ type CacheJob = {
     timer?: ReturnType<typeof setInterval>;
 };
 
-// This is going to use a Singleton pattern to manage cache jobs. The CacheScheduler will be responsible for scheduling and executing cache jobs at specified intervals. Each job will have a unique key, an interval in milliseconds, and a fetcher function that retrieves the data to be cached. The scheduler will use the ScrapeCache class to store and retrieve cached data.
+type CacheEntry = {
+    data: any;
+    cacheTime: number;
+};
+
+const OVERLY_OUTDATED_MS = 1000 * 60 * 60 * 24 * 7; // 1 week
+
 export class CacheScheduler {
-    private cache: ScrapeCache = new ScrapeCache();
+    private prisma: PrismaClient = getPrisma();
+    private store: Map<string, CacheEntry> = new Map();
     private jobs: { [key: string]: CacheJob } = {};
 
     registerLoop(key: string, intervalMs: number, fetcher: () => Promise<any>): void {
@@ -20,11 +25,26 @@ export class CacheScheduler {
         this.jobs[key] = { key, intervalMs, fetcher };
     }
 
+    getCache(key: string): CacheEntry | null {
+        const entry = this.store.get(key) ?? null;
+        if (entry && Date.now() - entry.cacheTime > OVERLY_OUTDATED_MS) return null;
+        return entry;
+    }
+
     start(): void {
+        // Seed in-memory store from persisted DB entries so the first requests
+        // are served immediately, before the initial fetcher runs finish.
+        this.seed();
         for (const job of Object.values(this.jobs)) {
             this.run(job);
             job.timer = setInterval(() => this.run(job), job.intervalMs);
         }
+    }
+
+    async __forceRefresh(key: string): Promise<void> {
+        const job = this.jobs[key];
+        if (!job) throw new Error(`No registered cache job for key: "${key}"`);
+        await this.run(job);
     }
 
     stop(): void {
@@ -33,8 +53,41 @@ export class CacheScheduler {
         }
     }
 
+    private async seed(): Promise<void> {
+        const entries = await this.prisma.webscrapeCache.findMany({
+            where: { cacheName: { in: Object.keys(this.jobs) } },
+        });
+        for (const entry of entries) {
+            if (!this.store.has(entry.cacheName)) {
+                this.store.set(entry.cacheName, {
+                    data: entry.data,
+                    cacheTime: Number(entry.cacheTime),
+                });
+            }
+        }
+    }
+
     private async run(job: CacheJob): Promise<void> {
         const data = await job.fetcher();
-        await this.cache.setCache(job.key, data);
+        const cacheTime = Date.now();
+        const expiry = cacheTime + job.intervalMs;
+
+        this.store.set(job.key, { data, cacheTime });
+
+        const exists = await this.prisma.webscrapeCache.findFirst({
+            where: { cacheName: job.key },
+        });
+        if (exists) {
+            await this.prisma.webscrapeCache.updateMany({
+                where: { cacheName: job.key },
+                data: { data, expiry, cacheTime },
+            });
+        } else {
+            await this.prisma.webscrapeCache.create({
+                data: { cacheName: job.key, data, expiry, cacheTime },
+            });
+        }
     }
 }
+
+export const scheduler = new CacheScheduler();

--- a/webserver/src/lib/cache-scheduler/scheduler.ts
+++ b/webserver/src/lib/cache-scheduler/scheduler.ts
@@ -1,0 +1,40 @@
+import { ScrapeCache } from "../../db/cache";
+import { PrismaClient } from "@prisma/client"
+import {getPrisma} from "../../db/client"
+
+
+type CacheJob = {
+    key: string;
+    intervalMs: number;
+    fetcher: () => Promise<any>;
+    timer?: ReturnType<typeof setInterval>;
+};
+
+// This is going to use a Singleton pattern to manage cache jobs. The CacheScheduler will be responsible for scheduling and executing cache jobs at specified intervals. Each job will have a unique key, an interval in milliseconds, and a fetcher function that retrieves the data to be cached. The scheduler will use the ScrapeCache class to store and retrieve cached data.
+export class CacheScheduler {
+    private cache: ScrapeCache = new ScrapeCache();
+    private jobs: { [key: string]: CacheJob } = {};
+
+    registerLoop(key: string, intervalMs: number, fetcher: () => Promise<any>): void {
+        if (this.jobs[key]) return;
+        this.jobs[key] = { key, intervalMs, fetcher };
+    }
+
+    start(): void {
+        for (const job of Object.values(this.jobs)) {
+            this.run(job);
+            job.timer = setInterval(() => this.run(job), job.intervalMs);
+        }
+    }
+
+    stop(): void {
+        for (const job of Object.values(this.jobs)) {
+            if (job.timer) clearInterval(job.timer);
+        }
+    }
+
+    private async run(job: CacheJob): Promise<void> {
+        const data = await job.fetcher();
+        await this.cache.setCache(job.key, data);
+    }
+}

--- a/webserver/src/routes/clubs/route.ts
+++ b/webserver/src/routes/clubs/route.ts
@@ -1,35 +1,25 @@
 import { Request, Response } from "express";
-import { ScrapeCache } from "../../db/cache";
+import { scheduler } from "../../lib/cache-scheduler/scheduler";
 import * as cheerio from "cheerio";
 
-const scrapeCache = new ScrapeCache();
+const CACHE_KEY = "club_infos";
 
+const fetchClubs = async () => {
+    const clubPage = await (await fetch("https://campusgroups.rit.edu/club_signup?view=all&group_type=9999")).text();
+    const $ = cheerio.load(clubPage);
 
-export async function GET(req: Request, res: Response) {
-    if(await scrapeCache.getCache("club_infos") && !(await scrapeCache.isExpired("club_infos"))) {
-        return res.header("Content-Type", "application/json").send(await scrapeCache.getCache("club_infos"));
-    }
-    let clubPage = await (await fetch("https://campusgroups.rit.edu/club_signup?view=all&group_type=9999")).text();
-    let $ = cheerio.load(clubPage);
+    const parsedClubs: { [key: string]: any }[] = [];
 
-    let clubList = $('.list-group-item').toArray();
-
-    let parsedClubs: { [key: string]: any }[] = [];
-
-    for (let club of clubList) {
-        // Club Name Parser
-        let clubName = $(club).find('.media-heading.header-cg--h4').text().trim();
+    for (const club of $('.list-group-item').toArray()) {
+        const clubName = $(club).find('.media-heading.header-cg--h4').text().trim();
         if (clubName === "") continue;
 
-        // Club type (e.g., Academic, Sports, Cultural)
         let clubType = $(club).find('.h5.media-heading.grey-element').text().trim().replaceAll("\t", " ").replaceAll("\n", " ");
         clubType = clubType.replaceAll(/\s+/g, " ");
 
-        // Mission Statement Parser
         let missionStatement = "";
-        let missionStatementScan = $(club).find('p');
-        for (let p of missionStatementScan.toArray()) {
-            if ($(p).attr("onclick") && $(p).attr("onclick")!.includes("mission")) {
+        for (const p of $(club).find('p').toArray()) {
+            if ($(p).attr("onclick")?.includes("mission")) {
                 missionStatement += $(p).text().trim() + " ";
             }
         }
@@ -37,21 +27,13 @@ export async function GET(req: Request, res: Response) {
         missionStatement = missionStatement.replaceAll(/\s+/g, " ");
         missionStatement = missionStatement.substring("Mission".length).trim();
 
-        // Detect if the club is full/closed
-        let fullClub = false;
-        $(club).find('.checkbox.checkbox-cg--group').toArray().forEach(p => {
-            if($(p).children().toArray().some(child => $(child).is('span'))) {
-                fullClub = true;
-            }
-        });
+        const fullClub = $(club).find('.checkbox.checkbox-cg--group').toArray()
+            .some(p => $(p).children().toArray().some(child => $(child).is('span')));
 
-        // Get image
-         let clubImage = $(club).find('.media-object.media-object--bordered').attr('src') || '';
+        let clubImage = $(club).find('.media-object.media-object--bordered').attr('src') || '';
         clubImage = "https://static-prod-us-east-1.campusgroups.com" + clubImage;
 
-        // Detect if the club is password locked.
-        let passwordLocked = false;
-        $(club).find('.listing-element__title-block').text().includes("Group password") ? passwordLocked = true : passwordLocked = false;
+        const passwordLocked = $(club).find('.listing-element__title-block').text().includes("Group password");
 
         parsedClubs.push({
             name: clubName,
@@ -61,8 +43,22 @@ export async function GET(req: Request, res: Response) {
             closed: fullClub,
             image: clubImage,
             isPasswordLocked: passwordLocked
-        })
+        });
     }
-    await scrapeCache.setCache("club_infos", parsedClubs);
-    res.header("Content-Type", "application/json").send(await scrapeCache.getCache("club_infos"));
+
+    return parsedClubs;
+};
+
+export const CACHEJOB = {
+    key: CACHE_KEY,
+    intervalMs: 1000 * 60 * 60 * 6, // 6 hours — club listings change infrequently
+    fetcher: fetchClubs,
+};
+
+export function GET(_req: Request, res: Response) {
+    const cached = scheduler.getCache(CACHE_KEY);
+    if (!cached) {
+        return res.status(503).json({ error: "Cache is warming up, try again shortly." });
+    }
+    return res.header("Content-Type", "application/json").json({ cachetime: cached.cacheTime, data: cached.data });
 }

--- a/webserver/src/routes/dining/route.ts
+++ b/webserver/src/routes/dining/route.ts
@@ -1,9 +1,7 @@
 import { Request, Response } from "express";
 import * as cheerio from "cheerio";
-import { getPrisma } from "../../db/client";
-import { ScrapeCache } from "../../db/cache";
+import { scheduler } from "../../lib/cache-scheduler/scheduler";
 
-// Define the structure of a restaurant type
 interface RestaurantType {
     id: number,
     name: string,
@@ -16,51 +14,25 @@ interface RestaurantType {
     busyLevel: number | null,
     hoursOfOperations?: { [day: string]: string[] } | null
 }
-// Define the dining types to scrape
+
+const CACHE_KEY = "dining_locations";
 const types = ["restaurant", "market", "coffee", "grocery"];
 
-// Prisma Client Setup
-const prisma = getPrisma();
-
-const scrapeCache = new ScrapeCache();
-const DINING_DEBUG = false
-
-// GET /dining/locations
-export async function GET(req: Request, res: Response) {
-
-    // // If cache exists and is recent (within 1 hour), return cached data
-    if (await scrapeCache.inCache("dining_locations") && !(await scrapeCache.isExpired("dining_locations")) || DINING_DEBUG) {
-        res.send(await scrapeCache.getCache("dining_locations"));
-        return;
-    }
-
-    // Otherwise, scrape new data and update cache
-    // Scrape dining locations from RIT website
+const fetchDining = async () => {
     const scrape = await fetch("https://www.rit.edu/dining/locations");
+    const $ = cheerio.load(await scrape.text());
 
-    // Get the HTML text from the response
-    const html = await scrape.text();
-
-    // Load HTML into Cheerio for parsing
-    const $ = cheerio.load(html);
-    // Initialize restaurant ID counter
     let onId = 0;
-
-    // Initialize array to hold restaurant data
     let restaurants: RestaurantType[] = [];
 
-    // Loop through each dining type and extract restaurant data
     for (const t of types) {
         $(`li[data-dining-type="${t}"]`).map((i, el) => {
-            const name = $(el).find('.font-weight-bold').text()
+            const name = $(el).find('.font-weight-bold').text();
             const status = $(el).find('.status-text').text();
-            // Link to restaurant details page
-            const link = $(el).find('a').attr("href")
+            const link = $(el).find('a').attr("href");
             const imageURL = $(el).find('.location-image').find("img").attr("src") || "";
-            // Extract busy level from image's file name. This looks like an interesting way to do it, but it works.
             const busyLevel = $(el).find('img[alt="Density"]').attr("src")?.split("people-")[1][0] || null;
 
-            // Push restaurant data to array
             restaurants.push({
                 id: onId++,
                 name: name.trim(),
@@ -72,54 +44,46 @@ export async function GET(req: Request, res: Response) {
                 link: "https://rit.edu" + link || "",
                 bannerImage: ""
             });
-        })
+        });
     }
 
-    // Get hours of operation for each restaurant
     for (let i = 0; i < restaurants.length; i++) {
-        // Get restaurant
         const r = restaurants[i];
+        if (!r.code) continue;
 
-        // Only fetch hours if restaurant has a valid code
-        if (r.code) {
-            // Fetch restaurant detail page
-            const detailScrape = await fetch(`${r.link}`);
-            // Load detail page HTML into Cheerio
-            const $storeScrape = cheerio.load(await detailScrape.text());
+        const $storeScrape = cheerio.load(await (await fetch(r.link)).text());
 
-            // Parse hours of operation by getting the week display div, taking all the day columns, and then iterating through them
-            $storeScrape('div[class="week-display"]').map((j, el) => {
-                $(el).find('div[class="day-column"]').map((k, dayEl) => {
-                    let dayName = $storeScrape(dayEl).find('div[class="day-name"]').text().trim();
-                    let hours = $storeScrape(dayEl).find('div[class="day-hours"]').html()?.split("<br>");
-                    console.log(dayName, hours?.map((e) => e.trim()));
-                    // Initialize hoursOfOperations object if it doesn't exist for whatever reason (shouldn't happen)
-                    if (!r.hoursOfOperations) {
-                        r.hoursOfOperations = {};
-                    }
-                    // r.hoursOfOperations[dayName] = hours;
-                    if(!Object.keys(r.hoursOfOperations).includes(dayName)) {
-                        r.hoursOfOperations[dayName] = hours?.map((e) => e.trim()) || [];
-                    }
-                })
-            });
-            // restaurants[i].bannerImage = $storeScrape("banner-item-2").find("img").map((x, el) => $storeScrape(el).attr("src")).get()[0] || "";
-            $storeScrape("#banner-item-2").map((x, el) => {
-                const src = $storeScrape(el).find("img").attr("src");
-                if(src) {
-                    restaurants[i].bannerImage = "https://rit.edu" + src;
+        $storeScrape('div[class="week-display"]').map((_j, el) => {
+            $storeScrape(el).find('div[class="day-column"]').map((_k, dayEl) => {
+                const dayName = $storeScrape(dayEl).find('div[class="day-name"]').text().trim();
+                const hours = $storeScrape(dayEl).find('div[class="day-hours"]').html()?.split("<br>");
+                if (!r.hoursOfOperations) r.hoursOfOperations = {};
+                if (!Object.keys(r.hoursOfOperations).includes(dayName)) {
+                    r.hoursOfOperations[dayName] = hours?.map((e) => e.trim()) || [];
                 }
-            })
-        }
+            });
+        });
+
+        $storeScrape("#banner-item-2").map((_x, el) => {
+            const src = $storeScrape(el).find("img").attr("src");
+            if (src) restaurants[i].bannerImage = "https://rit.edu" + src;
+        });
     }
 
-    // Update database cache
-    const currentTime = Date.now();
+    return { data: restaurants };
+};
 
-    await scrapeCache.setCache("dining_locations", {
-        data: restaurants
-    });
+export const CACHEJOB = {
+    key: CACHE_KEY,
+    intervalMs: 1000 * 60 * 30, // 30 minutes — keeps open/close status reasonably fresh
+    fetcher: fetchDining,
+};
 
-    // Return newly scraped data
-    res.send(await scrapeCache.getCache("dining_locations"));
+// GET /dining/locations
+export function GET(_req: Request, res: Response) {
+    const cached = scheduler.getCache(CACHE_KEY);
+    if (!cached) {
+        return res.status(503).json({ error: "Cache is warming up, try again shortly." });
+    }
+    return res.header("Content-Type", "application/json").json({ cachetime: cached.cacheTime, data: cached.data });
 }

--- a/webserver/src/routes/events/route.ts
+++ b/webserver/src/routes/events/route.ts
@@ -1,71 +1,64 @@
-import { ScrapeCache } from "../../db/cache";
+import { scheduler } from "../../lib/cache-scheduler/scheduler";
 import { Request, Response } from "express";
-
 import * as cheerio from "cheerio";
 
-const URLBuilder = async(range: number) => {
-  return `https://campusgroups.rit.edu/mobile_ws/v17/mobile_events_list?range=${range}&limit=40`;
-}
+const CACHE_KEY = "rit_events";
+const INCREMENTS = 10;
 
-const getEventData = async (increments: number) => {
-    let eventParsed: { [key:string] : string}[] = []
-    let eventTags: string[] = []
-    for(let i = 0; i < increments; i++) {
-      let events = await (await fetch(await URLBuilder(i*40))).json();
-      // Parse event
-      for(const event of events) {
-          let eventData: { [key: string]: any } = {}
-          let fields = event.fields.split(",");
-          for(let x = 0; x < fields.length; x++) {
-              if(fields[x].trim() == '') continue;
-              eventData[fields[x]] = event[`p${x}`];
-          }
-          if (eventData["eventName"]) {
-              let dates: string[] = [];
-              // eventData["eventDates"] = cheerio.load(eventData["eventDates"]).teHH
-              for(const date of cheerio.load(eventData["eventDates"])("p")) {
-                  let dateParse = cheerio.load(date).text().trim();
-                  if(dateParse != "" && !dates.includes(dateParse)) {
-                      dates.push(dateParse);
-                  }
-              }
-              eventData["eventDates"] = dates.join(" ");;
-          }
-          if (eventData["eventTags"]) {
-              let allTags: string[] =[];
-              for(const tag of cheerio.load(eventData["eventTags"])("a")) {
-                  let tagParse = cheerio.load(tag).text().trim();
-                  if(tagParse != "" && !eventTags.includes(tagParse)) {
-                      eventTags.push(tagParse);
-                  }
-                  allTags.push(tagParse);
-              }
-              eventData["eventTags"] = allTags;
-          }
-          eventParsed.push(eventData);
-      }
-    }
-    return {eventParsed, eventTags};
-}
-export const GET = async (req: Request, res: Response) => {
+const URLBuilder = (range: number) =>
+    `https://campusgroups.rit.edu/mobile_ws/v17/mobile_events_list?range=${range}&limit=40`;
 
-    const scrapeCache = new ScrapeCache();
-    if(await scrapeCache.getCache("rit_events") && !(await scrapeCache.isExpired("rit_events"))) {
-        return res.header("Content-Type", "application/json").send(await scrapeCache.getCache("rit_events"));
+const fetchEvents = async () => {
+    let eventParsed: { [key: string]: any }[] = [];
+    let eventTags: string[] = [];
+
+    for (let i = 0; i < INCREMENTS; i++) {
+        let events = await (await fetch(URLBuilder(i * 40))).json();
+        for (const event of events) {
+            let eventData: { [key: string]: any } = {};
+            let fields = event.fields.split(",");
+            for (let x = 0; x < fields.length; x++) {
+                if (fields[x].trim() == '') continue;
+                eventData[fields[x]] = event[`p${x}`];
+            }
+            if (eventData["eventName"]) {
+                let dates: string[] = [];
+                for (const date of cheerio.load(eventData["eventDates"])("p")) {
+                    let dateParse = cheerio.load(date).text().trim();
+                    if (dateParse != "" && !dates.includes(dateParse)) {
+                        dates.push(dateParse);
+                    }
+                }
+                eventData["eventDates"] = dates.join(" ");
+            }
+            if (eventData["eventTags"]) {
+                let allTags: string[] = [];
+                for (const tag of cheerio.load(eventData["eventTags"])("a")) {
+                    let tagParse = cheerio.load(tag).text().trim();
+                    if (tagParse != "" && !eventTags.includes(tagParse)) {
+                        eventTags.push(tagParse);
+                    }
+                    allTags.push(tagParse);
+                }
+                eventData["eventTags"] = allTags;
+            }
+            eventParsed.push(eventData);
+        }
     }
 
-    let cacheDataSet: {[key: string]: any } = {}
+    return { events: eventParsed, eventTags };
+};
 
-    let increments = 10;
-    let resp = await getEventData(increments);
-    let eventParsed = resp.eventParsed;
-    let eventTags = resp.eventTags;
+export const CACHEJOB = {
+    key: CACHE_KEY,
+    intervalMs: 1000 * 60 * 60, // 1 hour
+    fetcher: fetchEvents,
+};
 
-    cacheDataSet["events"] = eventParsed;
-    cacheDataSet["eventTags"] = eventTags;
-
-    console.log(JSON.stringify(cacheDataSet, null, 2));
-
-    await scrapeCache.setCache("rit_events", cacheDataSet);
-    res.header("Content-Type", "application/json").send(await scrapeCache.getCache("rit_events"));
-}
+export const GET = (_req: Request, res: Response) => {
+    const cached = scheduler.getCache(CACHE_KEY);
+    if (!cached) {
+        return res.status(503).json({ error: "Cache is warming up, try again shortly." });
+    }
+    return res.header("Content-Type", "application/json").json({ cachetime: cached.cacheTime, data: cached.data });
+};

--- a/webserver/src/routes/news.ts
+++ b/webserver/src/routes/news.ts
@@ -1,8 +1,7 @@
 import { Request, Response } from 'express';
 import * as cheerio from 'cheerio';
-import { ScrapeCache } from '../db/cache';
-// import fs  from 'fs'; used this to make a html file of rit news, just for debugging stuff 
-// psql -U postgres -h localhost -p 5433 -d ritApp to log into sql db on the termial, JUST TO LOOK AT DATA DO NOT USE RAW SQL WE HAVE PRISMA FOR A REASON
+import { scheduler } from '../lib/cache-scheduler/scheduler';
+
 interface NewsArticle {
   uri: string;
   title: string;
@@ -11,123 +10,76 @@ interface NewsArticle {
   image: string;
 }
 
-const scrapeCache = new ScrapeCache();
+const DEFAULT_PAGE = 0;
+const DEFAULT_PAGE_COUNT = 1;
+const CACHE_KEY = `news_page${DEFAULT_PAGE}_count${DEFAULT_PAGE_COUNT}`;
 
-/**
- * Scrapes news articles from RIT's news stories page
- * @param page - Page number (0-based)
- * @returns Array of news articles sorted by newest to oldest
- */
 async function scrapeRITNews(page: number = 0): Promise<NewsArticle[]> {
-  const baseUrl = 'https://www.rit.edu/news/news-stories';
-	const url = page > 0 ? `${baseUrl}?page=${page}` : baseUrl;
+    const baseUrl = 'https://www.rit.edu/news/news-stories';
+    const url = page > 0 ? `${baseUrl}?page=${page}` : baseUrl;
 
-	try {
-		const response = await fetch(url);
-		
-		if (!response.ok) {
-			throw new Error(`HTTP error! status: ${response.status}`);
-		}
-		
-		const html = await response.text();
-		const $ = cheerio.load(html);
-		
-		const articles: NewsArticle[] = [];
+    const response = await fetch(url);
+    if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
 
-		// Target the actual news articles
-		$('article.news-teaser').each((_, element) => {
-			const $article = $(element);
-			
-			// Get the date from card-header
-			const date = $article.find('.card-header').text().trim();
-			
-			// Get the main link
-			const $link = $article.find('a.card-link');
-			const href = $link.attr('href');
-			const title = $article.find('.card-title').text().trim();
-			
-			// Get the description from card-text
-			const description = $article.find('.card-text p').text().trim();
+    const $ = cheerio.load(await response.text());
+    const articles: NewsArticle[] = [];
 
-			// Get image of the news card
-			const image = $article.find('img.card-img-top').attr('src');
-			
-			// Only add if we have valid data
-			if (href && title) {
-				articles.push({
-					uri: href.startsWith('http') ? href : `https://www.rit.edu${href}`,
-					title: title.replace(/\s+/g, ' '), // Clean up extra whitespace
-					description: description || '',
-					date: date || 'Date not available',
-					image: "https://rit.edu" + image || ''
-				});
-			}
-		});
+    $('article.news-teaser').each((_, element) => {
+        const $article = $(element);
+        const date = $article.find('.card-header').text().trim();
+        const href = $article.find('a.card-link').attr('href');
+        const title = $article.find('.card-title').text().trim();
+        const description = $article.find('.card-text p').text().trim();
+        const image = $article.find('img.card-img-top').attr('src');
 
-		console.log(`Found ${articles.length} articles`);
-		return articles;
-		
-	} catch (error) {
-		console.error('Error scraping RIT news:', error);
-		throw error;
-	}
+        if (href && title) {
+            articles.push({
+                uri: href.startsWith('http') ? href : `https://www.rit.edu${href}`,
+                title: title.replace(/\s+/g, ' '),
+                description: description || '',
+                date: date || 'Date not available',
+                image: "https://rit.edu" + image || ''
+            });
+        }
+    });
+
+    return articles;
 }
 
-/**
- * GET /news
- * Query params:
- *   - page: Page number (0-based, optional, default: 0)
- *   - pageCount: Number of pages to fetch (optional, default: 1)
- * 
- * Returns array of news articles in format:
- * {
- *   cachetime: number,
- *   data: NewsArticle[]
- * }
- */
+async function fetchNewsPages(page: number, pageCount: number): Promise<NewsArticle[]> {
+    const allArticles: NewsArticle[] = [];
+    for (let i = 0; i < pageCount; i++) {
+        allArticles.push(...await scrapeRITNews(page + i));
+    }
+    return allArticles;
+}
+
+export const CACHEJOB = {
+    key: CACHE_KEY,
+    intervalMs: 1000 * 60 * 60, // 1 hour
+    fetcher: () => fetchNewsPages(DEFAULT_PAGE, DEFAULT_PAGE_COUNT),
+};
+
 export async function GET(req: Request, res: Response) {
-	try {
-		const page = parseInt(req.query.page as string) || 0;
-		const pageCountParam = parseInt(req.query.pageCount as string);
-		const pageCount = pageCountParam && pageCountParam > 0 ? pageCountParam : 1;
+    const page = parseInt(req.query.page as string) || DEFAULT_PAGE;
+    const pageCount = parseInt(req.query.pageCount as string) || DEFAULT_PAGE_COUNT;
+    const isDefault = page === DEFAULT_PAGE && pageCount === DEFAULT_PAGE_COUNT;
 
-		// Create cache key based on page and pageCount
-		const cacheKey = `news_page${page}_count${pageCount}`; //for some reason this isn't working because of caching reasons that I dont know
-    //const cacheKey = `news_v2_page${page}_count${pageCount}`;
+    if (isDefault) {
+        const cached = scheduler.getCache(CACHE_KEY);
+        if (!cached) {
+            return res.status(503).json({ error: "Cache is warming up, try again shortly." });
+        }
+        return res.json({ cachetime: cached.cacheTime, data: cached.data });
+    }
 
-		// TEMPORARILY DISABLE CACHE FOR DEBUGGING
-		const bypassCache = req.query.nocache === 'true';
-
-		// Check if cache exists and is not expired
-		if (!bypassCache && await scrapeCache.inCache(cacheKey) && !(await scrapeCache.isExpired(cacheKey))) {
-			console.log('Returning cached data');
-			res.send(await scrapeCache.getCache(cacheKey));
-			return;
-		}
-
-		console.log('Scraping fresh data...');
-
-		// Otherwise, scrape new data
-		let allArticles: NewsArticle[] = [];
-		
-		// Fetch multiple pages if requested
-		for (let i = 0; i < pageCount; i++) {
-			const articles = await scrapeRITNews(page + i);
-			allArticles.push(...articles);
-		}
-
-		// Cache the results
-		await scrapeCache.setCache(cacheKey, allArticles);
-
-		// Return newly scraped data
-		res.send(await scrapeCache.getCache(cacheKey));
-		
-	} catch (error) {
-		console.error('Error fetching news:', error);
-		res.status(500).json({
-			success: false,
-			error: 'Failed to fetch news articles',
-			message: error instanceof Error ? error.message : 'Unknown error'
-		});
-	}
+    try {
+        const articles = await fetchNewsPages(page, pageCount);
+        return res.json({ cachetime: Date.now(), data: articles });
+    } catch (error) {
+        return res.status(500).json({
+            error: 'Failed to fetch news articles',
+            message: error instanceof Error ? error.message : 'Unknown error'
+        });
+    }
 }


### PR DESCRIPTION
## Summary

- Introduces `CacheScheduler`, a new background scheduling system in `webserver/src/lib/cache-scheduler/` that replaces the request-triggered caching model in `src/db/cache.ts`
- The scheduler maintains an in-memory store per cache key, refreshes data on a fixed interval independent of user traffic, and persists entries to the existing Prisma `WebscrapeCache` table — so cached data survives restarts
- On startup, `App.ts` seeds the in-memory store from the database before any jobs fire, then automatically detects and registers any route that exports a `CACHEJOB`
- Migrated four routes off `ScrapeCache` and onto the scheduler: **events**, **dining locations**, **clubs**, and **news** (default page only — non-default page/count combos remain lazily fetched to avoid unnecessary upstream load)
- Added `__forceRefresh(key)` as a debug utility for manually triggering a cache refresh outside the scheduled interval
- Added a one-week staleness guard in `getCache` — entries older than `OVERLY_OUTDATED_MS` are withheld and the route returns a 503, preventing severely dated data from ever reaching clients

## Staying the same

- `src/db/cache.ts` (`ScrapeCache`) is still present and untouched; per-request lazy caches (e.g. `events/getinfo.ts` per-event detail, dining menus) continue using it as-is since pre-fetching every possible key would strain upstream servers
- The Prisma schema and database table are unchanged — the scheduler writes to the same `WebscrapeCache` model